### PR TITLE
Reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ categories = ["game-engines", "rendering"]
 [dependencies]
 bevy = { version = "0.8", default-features = false, features = [
     "bevy_asset",
-    "render",
+    "bevy_render",
+    "bevy_pbr",
+    "bevy_core_pipeline",
 ] }
 thiserror = "1.0"
 
@@ -22,6 +24,10 @@ bevy = { version = "0.8", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }
+
+[features]
+default = ["bevy_ui"]
+bevy_ui = ["bevy/bevy_ui"]
 
 [[example]]
 name = "shapes"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,7 @@ impl Plugin for OutlinePlugin {
                 OUTLINE_PASS_NODE_NAME,
             )
             .unwrap();
+        #[cfg(feature = "bevy_ui")]
         draw_3d_graph
             .add_node_edge(
                 OUTLINE_PASS_NODE_NAME,


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202 and also see https://github.com/bevyengine/bevy/issues/5753