### PR TITLE
Introduce OutlineRenderLayers for masking which views an outline appears on

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -19,7 +19,7 @@ pub type DrawStencil = (
     DrawMesh,
 );
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn queue_outline_stencil_mesh(
     stencil_draw_functions: Res<DrawFunctions<StencilOutline>>,
     stencil_pipeline: Res<OutlinePipeline>,
@@ -77,7 +77,7 @@ pub type DrawOutline = (
     DrawMesh,
 );
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn queue_outline_mesh(
     opaque_draw_functions: Res<DrawFunctions<OpaqueOutline>>,
     transparent_draw_functions: Res<DrawFunctions<TransparentOutline>>,

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -5,11 +5,11 @@ use bevy::render::render_phase::{DrawFunctions, RenderPhase, SetItemPipeline};
 use bevy::render::render_resource::{PipelineCache, SpecializedMeshPipelines};
 use bevy::render::view::{ExtractedView, RenderLayers};
 
-use crate::OutlineRenderLayers;
 use crate::node::{OpaqueOutline, StencilOutline, TransparentOutline};
 use crate::pipeline::{OutlinePipeline, PassType};
 use crate::uniforms::{OutlineFragmentUniform, SetOutlineBindGroup};
 use crate::view_uniforms::SetOutlineViewBindGroup;
+use crate::OutlineRenderLayers;
 use crate::OutlineStencil;
 
 pub type DrawStencil = (
@@ -27,8 +27,20 @@ pub fn queue_outline_stencil_mesh(
     mut pipelines: ResMut<SpecializedMeshPipelines<OutlinePipeline>>,
     mut pipeline_cache: ResMut<PipelineCache>,
     render_meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>, Option<&OutlineRenderLayers>), With<OutlineStencil>>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<StencilOutline>, Option<&RenderLayers>)>,
+    material_meshes: Query<
+        (
+            Entity,
+            &MeshUniform,
+            &Handle<Mesh>,
+            Option<&OutlineRenderLayers>,
+        ),
+        With<OutlineStencil>,
+    >,
+    mut views: Query<(
+        &ExtractedView,
+        &mut RenderPhase<StencilOutline>,
+        Option<&RenderLayers>,
+    )>,
 ) {
     let draw_stencil = stencil_draw_functions
         .read()
@@ -86,7 +98,13 @@ pub fn queue_outline_mesh(
     mut pipelines: ResMut<SpecializedMeshPipelines<OutlinePipeline>>,
     mut pipeline_cache: ResMut<PipelineCache>,
     render_meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>, &OutlineFragmentUniform, Option<&OutlineRenderLayers>)>,
+    material_meshes: Query<(
+        Entity,
+        &MeshUniform,
+        &Handle<Mesh>,
+        &OutlineFragmentUniform,
+        Option<&OutlineRenderLayers>,
+    )>,
     mut views: Query<(
         &ExtractedView,
         &mut RenderPhase<OpaqueOutline>,
@@ -108,7 +126,9 @@ pub fn queue_outline_mesh(
     for (view, mut opaque_phase, mut transparent_phase, view_mask) in views.iter_mut() {
         let view_mask = view_mask.copied().unwrap_or_default();
         let rangefinder = view.rangefinder3d();
-        for (entity, mesh_uniform, mesh_handle, outline_fragment, outline_mask) in material_meshes.iter() {
+        for (entity, mesh_uniform, mesh_handle, outline_fragment, outline_mask) in
+            material_meshes.iter()
+        {
             let outline_mask = outline_mask.copied().unwrap_or_default();
             if !view_mask.intersects(&outline_mask) {
                 continue;

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -3,8 +3,9 @@ use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{DrawFunctions, RenderPhase, SetItemPipeline};
 use bevy::render::render_resource::{PipelineCache, SpecializedMeshPipelines};
-use bevy::render::view::ExtractedView;
+use bevy::render::view::{ExtractedView, RenderLayers};
 
+use crate::OutlineRenderLayers;
 use crate::node::{OpaqueOutline, StencilOutline, TransparentOutline};
 use crate::pipeline::{OutlinePipeline, PassType};
 use crate::uniforms::{OutlineFragmentUniform, SetOutlineBindGroup};
@@ -26,8 +27,8 @@ pub fn queue_outline_stencil_mesh(
     mut pipelines: ResMut<SpecializedMeshPipelines<OutlinePipeline>>,
     mut pipeline_cache: ResMut<PipelineCache>,
     render_meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>), With<OutlineStencil>>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<StencilOutline>)>,
+    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>, Option<&OutlineRenderLayers>), With<OutlineStencil>>,
+    mut views: Query<(&ExtractedView, &mut RenderPhase<StencilOutline>, Option<&RenderLayers>)>,
 ) {
     let draw_stencil = stencil_draw_functions
         .read()
@@ -36,9 +37,14 @@ pub fn queue_outline_stencil_mesh(
 
     let base_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
 
-    for (view, mut stencil_phase) in views.iter_mut() {
+    for (view, mut stencil_phase, view_mask) in views.iter_mut() {
         let rangefinder = view.rangefinder3d();
-        for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
+        let view_mask = view_mask.copied().unwrap_or_default();
+        for (entity, mesh_uniform, mesh_handle, outline_mask) in material_meshes.iter() {
+            let outline_mask = outline_mask.copied().unwrap_or_default();
+            if !view_mask.intersects(&outline_mask) {
+                continue;
+            }
             if let Some(mesh) = render_meshes.get(mesh_handle) {
                 let key =
                     base_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
@@ -80,11 +86,12 @@ pub fn queue_outline_mesh(
     mut pipelines: ResMut<SpecializedMeshPipelines<OutlinePipeline>>,
     mut pipeline_cache: ResMut<PipelineCache>,
     render_meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>, &OutlineFragmentUniform)>,
+    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>, &OutlineFragmentUniform, Option<&OutlineRenderLayers>)>,
     mut views: Query<(
         &ExtractedView,
         &mut RenderPhase<OpaqueOutline>,
         &mut RenderPhase<TransparentOutline>,
+        Option<&RenderLayers>,
     )>,
 ) {
     let draw_opaque_outline = opaque_draw_functions
@@ -98,9 +105,14 @@ pub fn queue_outline_mesh(
 
     let base_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
 
-    for (view, mut opaque_phase, mut transparent_phase) in views.iter_mut() {
+    for (view, mut opaque_phase, mut transparent_phase, view_mask) in views.iter_mut() {
+        let view_mask = view_mask.copied().unwrap_or_default();
         let rangefinder = view.rangefinder3d();
-        for (entity, mesh_uniform, mesh_handle, outline_fragment) in material_meshes.iter() {
+        for (entity, mesh_uniform, mesh_handle, outline_fragment, outline_mask) in material_meshes.iter() {
+            let outline_mask = outline_mask.copied().unwrap_or_default();
+            if !view_mask.intersects(&outline_mask) {
+                continue;
+            }
             if let Some(mesh) = render_meshes.get(mesh_handle) {
                 let transparent = outline_fragment.colour[3] < 1.0;
                 let pass_type;

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -87,7 +87,6 @@ fn auto_generate_outline_normals(
     mut squelch: Local<HashSet<Handle<Mesh>>>,
 ) {
     for event in events.iter() {
-        println!("{:?}", event);
         match event {
             AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                 if squelch.contains(handle) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ use bevy::render::mesh::MeshVertexAttribute;
 use bevy::render::render_graph::RenderGraph;
 use bevy::render::render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions};
 use bevy::render::render_resource::{SpecializedMeshPipelines, VertexFormat};
-use bevy::render::{RenderApp, RenderStage};
 use bevy::render::view::RenderLayers;
+use bevy::render::{RenderApp, RenderStage};
 
 use crate::draw::{queue_outline_mesh, queue_outline_stencil_mesh, DrawOutline, DrawStencil};
 use crate::node::{OpaqueOutline, OutlineNode, StencilOutline, TransparentOutline};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use bevy::render::render_graph::RenderGraph;
 use bevy::render::render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions};
 use bevy::render::render_resource::{SpecializedMeshPipelines, VertexFormat};
 use bevy::render::{RenderApp, RenderStage};
+use bevy::render::view::RenderLayers;
 
 use crate::draw::{queue_outline_mesh, queue_outline_stencil_mesh, DrawOutline, DrawStencil};
 use crate::node::{OpaqueOutline, OutlineNode, StencilOutline, TransparentOutline};
@@ -84,6 +85,10 @@ pub struct Outline {
     /// Colour of the outline
     pub colour: Color,
 }
+
+/// A component for specifying what layer(s) the outline should be rendered for
+#[derive(Clone, Copy, Component, Default, Deref, DerefMut)]
+pub struct OutlineRenderLayers(pub RenderLayers);
 
 /// A bundle for rendering stenciled outlines around meshes.
 #[derive(Bundle, Clone, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,15 @@ pub struct Outline {
 #[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Deref, DerefMut, Default)]
 pub struct OutlineRenderLayers(pub RenderLayers);
 
+impl ExtractComponent for OutlineRenderLayers {
+    type Query = &'static OutlineRenderLayers;
+    type Filter = ();
+
+    fn extract_component(item: &OutlineRenderLayers) -> Self {
+        *item
+    }
+}
+
 /// A bundle for rendering stenciled outlines around meshes.
 #[derive(Bundle, Clone, Default)]
 pub struct OutlineBundle {
@@ -117,6 +126,7 @@ impl Plugin for OutlinePlugin {
         );
 
         app.add_plugin(ExtractComponentPlugin::<OutlineStencil>::extract_visible())
+            .add_plugin(ExtractComponentPlugin::<OutlineRenderLayers>::default())
             .add_plugin(UniformComponentPlugin::<OutlineVertexUniform>::default())
             .add_plugin(UniformComponentPlugin::<OutlineFragmentUniform>::default())
             .add_plugin(UniformComponentPlugin::<OutlineViewUniform>::default())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub struct Outline {
 }
 
 /// A component for specifying what layer(s) the outline should be rendered for
-#[derive(Clone, Copy, Component, Default, Deref, DerefMut)]
+#[derive(Component, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Deref, DerefMut, Default)]
 pub struct OutlineRenderLayers(pub RenderLayers);
 
 /// A bundle for rendering stenciled outlines around meshes.

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -13,7 +13,7 @@ use bevy::{
     },
 };
 
-use crate::{pipeline::OutlinePipeline, Outline, OutlineRenderLayers};
+use crate::{pipeline::OutlinePipeline, Outline};
 
 #[derive(Clone, Component, ShaderType)]
 pub struct OutlineVertexUniform {
@@ -31,11 +31,8 @@ pub struct OutlineBindGroup {
     pub bind_group: BindGroup,
 }
 
-pub fn extract_outline_uniforms(
-    mut commands: Commands,
-    query: Extract<Query<(Entity, &Outline, Option<&OutlineRenderLayers>)>>,
-) {
-    for (entity, outline, outline_mask) in query.iter() {
+pub fn extract_outline_uniforms(mut commands: Commands, query: Extract<Query<(Entity, &Outline)>>) {
+    for (entity, outline) in query.iter() {
         if !outline.visible || outline.colour.a() == 0.0 {
             continue;
         }
@@ -47,10 +44,6 @@ pub fn extract_outline_uniforms(
             .insert(OutlineFragmentUniform {
                 colour: outline.colour.as_linear_rgba_f32().into(),
             });
-
-        if let Some(outline_mask) = outline_mask {
-            entity_commands.insert(*outline_mask);
-        }
     }
 }
 

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -31,7 +31,10 @@ pub struct OutlineBindGroup {
     pub bind_group: BindGroup,
 }
 
-pub fn extract_outline_uniforms(mut commands: Commands, query: Extract<Query<(Entity, &Outline, Option<&OutlineRenderLayers>)>>) {
+pub fn extract_outline_uniforms(
+    mut commands: Commands,
+    query: Extract<Query<(Entity, &Outline, Option<&OutlineRenderLayers>)>>,
+) {
     for (entity, outline, outline_mask) in query.iter() {
         if !outline.visible || outline.colour.a() == 0.0 {
             continue;

--- a/src/view_uniforms.rs
+++ b/src/view_uniforms.rs
@@ -8,6 +8,7 @@ use bevy::render::render_phase::{
 use bevy::render::render_resource::ShaderType;
 use bevy::render::render_resource::{BindGroup, BindGroupDescriptor, BindGroupEntry};
 use bevy::render::renderer::RenderDevice;
+use bevy::render::view::RenderLayers;
 use bevy::render::Extract;
 
 use crate::node::{OpaqueOutline, StencilOutline, TransparentOutline};
@@ -25,19 +26,23 @@ pub struct OutlineViewBindGroup {
 
 pub fn extract_outline_view_uniforms(
     mut commands: Commands,
-    query: Extract<Query<(Entity, &Camera), With<Camera3d>>>,
+    query: Extract<Query<(Entity, &Camera, Option<&RenderLayers>), With<Camera3d>>>,
 ) {
-    for (entity, camera) in query.iter() {
+    for (entity, camera, view_mask) in query.iter() {
         if !camera.is_active {
             continue;
         }
         if let Some(size) = camera.logical_viewport_size() {
-            commands
-                .get_or_spawn(entity)
+            let mut entity_commands = commands.get_or_spawn(entity);
+            entity_commands
                 .insert(OutlineViewUniform { scale: 2.0 / size })
                 .insert(RenderPhase::<StencilOutline>::default())
                 .insert(RenderPhase::<OpaqueOutline>::default())
                 .insert(RenderPhase::<TransparentOutline>::default());
+
+            if let Some(view_mask) = view_mask {
+                entity_commands.insert(*view_mask);
+            }
         }
     }
 }

--- a/src/view_uniforms.rs
+++ b/src/view_uniforms.rs
@@ -24,6 +24,7 @@ pub struct OutlineViewBindGroup {
     bind_group: BindGroup,
 }
 
+#[allow(clippy::type_complexity)]
 pub fn extract_outline_view_uniforms(
     mut commands: Commands,
     query: Extract<Query<(Entity, &Camera, Option<&RenderLayers>), With<Camera3d>>>,


### PR DESCRIPTION
This PR introduces a new optional component `OutlineRenderLayer` which is checked against the `RenderLayers` of each view to determine whether the outline should be rendered in that view. To use `OutlineRenderLayer`, insert it for the same entity that has the `Outline` component.

If `OutlineRenderLayer` is not provided then the outline will be rendered as if the value inside `OutlineRenderLayer` is `RenderLayer::default()` to be consistent with the usual behavior that `RenderLayer` has when applied to a mesh.