### PR TITLE
Fix panic when some objects cannot have specialized mesh pipelines.

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -162,9 +162,10 @@ pub(crate) fn queue_outline_volume_mesh(
                     .with_depth_mode(volume_flags.depth_mode)
                     .with_offset_zero(volume_uniform.offset == 0.0)
                     .with_hdr_format(view.hdr);
-                let pipeline = pipelines
-                    .specialize(&pipeline_cache, &outline_pipeline, key, &mesh.layout)
-                    .unwrap();
+                let Ok(pipeline) = pipelines
+                    .specialize(&pipeline_cache, &outline_pipeline, key, &mesh.layout) else {
+                        continue;
+                    };
                 let distance = rangefinder.distance(&Mat4::from_translation(volume_uniform.origin));
                 if transparent {
                     transparent_phase.add(TransparentOutline {


### PR DESCRIPTION
I was trying to use this crate together with [this crate](https://github.com/mattatz/bevy_points) and found `bevy_mod_outline` panicking. There may be times where a user adds objects that cannot produce speciallized pipelines (for instance in this case, the crate does not populate normals). It seems to me there is no need to panic in these cases and just move on. In the worst case we probably should log a warning of some form.