### PR TITLE
(WIP) Update to bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bevy = { version = "0.11", default-features = false, features = [
     "png",
     "x11",
 ] }
-bevy_mod_gltf_patched = { git = "https://github.com/luggage66/bevy_mod_gltf_patched/", branch = "bevy-0.11" }
+bevy_mod_gltf_patched = { git = "https://github.com/zainthemaynnn/bevy_mod_gltf_patched/", branch = "bevy-0.11" }
 
 [features]
 default = ["bevy_ui"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,27 +11,31 @@ keywords = ["gamedev", "bevy", "outline"]
 categories = ["game-engines", "rendering"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
     "bevy_pbr",
+    "ktx2", 
+    "tonemapping_luts", 
+    "zstd",
     "bevy_core_pipeline",
 ] }
 bitfield = "0.14"
 interpolation = "0.2"
 thiserror = "1.0"
-wgpu-types = "0.15"
+wgpu-types = "0.16.1"
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
     "animation",
     "bevy_gltf",
+    "bevy_pbr",
     "bevy_scene",
     "bevy_winit",
     "png",
     "x11",
 ] }
-bevy_mod_gltf_patched = "0.2"
+bevy_mod_gltf_patched = { git = "https://github.com/luggage66/bevy_mod_gltf_patched/", branch = "bevy-0.11" }
 
 [features]
 default = ["bevy_ui"]

--- a/examples/animated_fox.rs
+++ b/examples/animated_fox.rs
@@ -14,16 +14,13 @@ struct Fox(Handle<AnimationClip>);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(OutlinePlugin)
-        .add_plugin(AutoGenerateOutlineNormalsPlugin)
+        .add_plugins((DefaultPlugins, OutlinePlugin, AutoGenerateOutlineNormalsPlugin))
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 1.0,
         })
-        .add_startup_system(setup)
-        .add_system(setup_scene_once_loaded)
-        .add_system(close_on_esc)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (setup_scene_once_loaded, close_on_esc))
         .run();
 }
 

--- a/examples/hollow.rs
+++ b/examples/hollow.rs
@@ -9,20 +9,17 @@ fn main() {
         // Disable built-in glTF plugin
         .add_plugins(DefaultPlugins.build().disable::<bevy::gltf::GltfPlugin>())
         // Register outline normal vertex attribute with bevy_mod_gltf_patched
-        .add_plugin(
+        .add_plugins(
             GltfPlugin::default()
                 .add_custom_vertex_attribute("_OUTLINE_NORMAL", ATTRIBUTE_OUTLINE_NORMAL),
         )
-        .add_plugin(OutlinePlugin)
+        .add_plugins(OutlinePlugin)
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 1.0,
         })
-        .add_startup_system(setup)
-        .add_system(setup_scene_once_loaded)
-        .add_system(rotates)
-        .add_system(rotates_hue)
-        .add_system(close_on_esc)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (setup_scene_once_loaded, rotates, rotates_hue, close_on_esc))
         .run();
 }
 

--- a/examples/pieces.rs
+++ b/examples/pieces.rs
@@ -15,11 +15,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins)
-        .add_plugin(OutlinePlugin)
-        .add_startup_system(setup)
-        .add_system(close_on_esc)
-        .add_system(rotates)
+        .add_plugins((DefaultPlugins, OutlinePlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (close_on_esc, rotates))
         .run();
 }
 

--- a/examples/render_layers.rs
+++ b/examples/render_layers.rs
@@ -16,11 +16,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins)
-        .add_plugin(OutlinePlugin)
-        .add_startup_system(setup)
-        .add_system(close_on_esc)
-        .add_system(set_camera_viewports)
+        .add_plugins((DefaultPlugins, OutlinePlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (close_on_esc, set_camera_viewports))
         .run();
 }
 

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -15,12 +15,9 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins)
-        .add_plugin(OutlinePlugin)
-        .add_startup_system(setup)
-        .add_system(close_on_esc)
-        .add_system(wobble)
-        .add_system(orbit)
+        .add_plugins((DefaultPlugins, OutlinePlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (close_on_esc, wobble, orbit))
         .run();
 }
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -74,7 +74,8 @@ pub(crate) fn queue_outline_stencil_mesh(
                 let key = base_key
                     .with_primitive_topology(mesh.primitive_topology)
                     .with_depth_mode(stencil_flags.depth_mode)
-                    .with_offset_zero(stencil_uniform.offset == 0.0);
+                    .with_offset_zero(stencil_uniform.offset == 0.0)
+                    .with_morph_targets(mesh.morph_targets.is_some());
                 let pipeline = pipelines
                     .specialize(&pipeline_cache, &stencil_pipeline, key, &mesh.layout)
                     .unwrap();
@@ -161,7 +162,8 @@ pub(crate) fn queue_outline_volume_mesh(
                     })
                     .with_depth_mode(volume_flags.depth_mode)
                     .with_offset_zero(volume_uniform.offset == 0.0)
-                    .with_hdr_format(view.hdr);
+                    .with_hdr_format(view.hdr)
+                    .with_morph_targets(mesh.morph_targets.is_some());
                 let pipeline = pipelines
                     .specialize(&pipeline_cache, &outline_pipeline, key, &mesh.layout)
                     .unwrap();

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -168,6 +168,6 @@ pub struct AutoGenerateOutlineNormalsPlugin;
 
 impl Plugin for AutoGenerateOutlineNormalsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(auto_generate_outline_normals);
+        app.add_systems(Update, auto_generate_outline_normals);
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,7 +3,7 @@ use std::cmp::Reverse;
 use bevy::ecs::system::lifetimeless::Read;
 use bevy::prelude::*;
 use bevy::render::camera::ExtractedCamera;
-use bevy::render::render_graph::{NodeRunError, SlotInfo, SlotType};
+use bevy::render::render_graph::NodeRunError;
 use bevy::render::render_phase::{
     CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem, RenderPhase,
 };
@@ -128,8 +128,6 @@ pub(crate) struct OutlineNode {
 }
 
 impl OutlineNode {
-    pub(crate) const IN_VIEW: &'static str = "view";
-
     pub(crate) fn new(world: &mut World) -> Self {
         Self {
             query: world.query_filtered(),
@@ -138,10 +136,6 @@ impl OutlineNode {
 }
 
 impl Node for OutlineNode {
-    fn input(&self) -> Vec<SlotInfo> {
-        vec![SlotInfo::new(Self::IN_VIEW, SlotType::Entity)]
-    }
-
     fn update(&mut self, world: &mut World) {
         self.query.update_archetypes(world);
     }
@@ -152,7 +146,7 @@ impl Node for OutlineNode {
         render_context: &mut RenderContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
-        let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
+        let view_entity = graph.view_entity();
         let (camera, stencil_phase, opaque_phase, transparent_phase, camera_3d, target, depth) =
             match self.query.get_manual(world, view_entity) {
                 Ok(query) => query,

--- a/src/outline.wgsl
+++ b/src/outline.wgsl
@@ -8,8 +8,8 @@ struct VertexInput {
     @location(1) normal: vec3<f32>,
 #endif
 #ifdef SKINNED
-    @location(2) joint_indexes: vec4<u32>,
-    @location(3) joint_weights: vec4<f32>,
+    @location(5) joint_indices: vec4<u32>,
+    @location(6) joint_weights: vec4<f32>,
 #endif
 };
 
@@ -37,11 +37,8 @@ var<uniform> view: View;
 @group(1) @binding(0)
 var<uniform> mesh: Mesh;
 
-#ifdef SKINNED
-@group(1) @binding(1)
-var<uniform> joint_matrices: SkinnedMesh;
 #import bevy_pbr::skinning
-#endif
+#import bevy_pbr::morph
 
 @group(2) @binding(0)
 var<uniform> view_uniform: OutlineViewUniform;
@@ -66,7 +63,7 @@ fn model_origin_z(plane: vec3<f32>, view_proj: mat4x4<f32>) -> f32 {
 @vertex
 fn vertex(vertex: VertexInput) -> VertexOutput {
 #ifdef SKINNED
-    let model = bevy_pbr::skinning::skin_model(vertex.joint_indexes, vertex.joint_weights);
+    let model = bevy_pbr::skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
 #else
     let model = mesh.model;
 #endif

--- a/src/outline.wgsl
+++ b/src/outline.wgsl
@@ -1,5 +1,6 @@
-#import bevy_pbr::mesh_view_bindings
-#import bevy_pbr::mesh_types
+#import bevy_render::view  View
+#import bevy_pbr::mesh_types Mesh
+#import bevy_pbr::mesh_types SkinnedMesh
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
@@ -29,6 +30,9 @@ struct OutlineVertexUniform {
     origin: vec3<f32>,
     offset: f32,
 };
+
+@group(0) @binding(0)
+var<uniform> view: View;
 
 @group(1) @binding(0)
 var<uniform> mesh: Mesh;
@@ -62,7 +66,7 @@ fn model_origin_z(plane: vec3<f32>, view_proj: mat4x4<f32>) -> f32 {
 @vertex
 fn vertex(vertex: VertexInput) -> VertexOutput {
 #ifdef SKINNED
-    let model = skin_model(vertex.joint_indexes, vertex.joint_weights);
+    let model = bevy_pbr::skinning::skin_model(vertex.joint_indexes, vertex.joint_weights);
 #else
     let model = mesh.model;
 #endif

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use bevy::pbr::{MAX_CASCADES_PER_LIGHT, MAX_DIRECTIONAL_LIGHTS};
 use bevy::prelude::*;
 use bevy::reflect::TypeUuid;
 use bevy::render::render_resource::{
@@ -232,27 +231,19 @@ impl SpecializedMeshPipeline for OutlinePipeline {
             self.mesh_pipeline.view_layout_multisampled.clone()
         }];
         let mut buffer_attrs = vec![Mesh::ATTRIBUTE_POSITION.at_shader_location(0)];
-        let mut vertex_defs = vec![
-            ShaderDefVal::Int(
-                "MAX_CASCADES_PER_LIGHT".to_string(),
-                MAX_CASCADES_PER_LIGHT as i32,
-            ),
-            ShaderDefVal::Int(
-                "MAX_DIRECTIONAL_LIGHTS".to_string(),
-                MAX_DIRECTIONAL_LIGHTS as i32,
-            ),
-        ];
+        let mut vertex_defs = vec![];
         let mut fragment_defs = vec![];
         bind_layouts.push(
             if mesh_layout.contains(Mesh::ATTRIBUTE_JOINT_INDEX)
                 && mesh_layout.contains(Mesh::ATTRIBUTE_JOINT_WEIGHT)
             {
                 vertex_defs.push(ShaderDefVal::from("SKINNED"));
+                vertex_defs.push("MESH_BINDGROUP_1".into());
                 buffer_attrs.push(Mesh::ATTRIBUTE_JOINT_INDEX.at_shader_location(2));
                 buffer_attrs.push(Mesh::ATTRIBUTE_JOINT_WEIGHT.at_shader_location(3));
-                self.mesh_pipeline.skinned_mesh_layout.clone()
+                self.mesh_pipeline.mesh_layouts.skinned.clone()
             } else {
-                self.mesh_pipeline.mesh_layout.clone()
+                self.mesh_pipeline.mesh_layouts.model_only.clone()
             },
         );
         bind_layouts.push(self.outline_view_bind_group_layout.clone());


### PR DESCRIPTION
I got this to a state where it's working well enough for my purposes but will likely need a couple tweaks.

Major concerns:
- Dependent on ~~[this fork of bevy_mod_gltf_patched](https://github.com/luggage66/bevy_mod_gltf_patched/)~~ [this fork of bevy_mod_gltf_patched](https://github.com/zainthemaynnn/bevy_mod_gltf_patched) until it gets updated
- ~~Doesn't support morph targets (maybe could be handled as a separate issue?)~~
  - @zainthemaynnn resolved this, although maybe an example using the same assets as in the [Bevy example](https://github.com/bevyengine/bevy/blob/main/examples/animation/morph_targets.rs) similar to the animated_fox one could be added?
- END_MAIN_PASS vs START_MAIN_PASS
    - with START_MAIN_PASS I noticed sometimes the outlines wouldn't appear at all... using END_MAIN_PASS seems to work more consistently but may be more transparent in some cases
 - Needed to add MESH_BINDGROUP_1 to get skinned meshes to work, but I suspect that should be handled differently
 
Most of the rest of the changes were from following the migration guide