### PR TITLE
Fixed B0004 warning in `bloom.rs`.

### DIFF
--- a/examples/bloom.rs
+++ b/examples/bloom.rs
@@ -46,7 +46,7 @@ fn setup(
 
     // Add satellite
     commands
-        .spawn(Transform::default())
+        .spawn((Transform::default(), InheritedVisibility::default()))
         .insert(Rotates)
         .with_children(|parent| {
             parent.spawn((


### PR DESCRIPTION
Fixed [b0004](https://bevyengine.org/learn/errors/b0004/) warning in `bloom.rs`.