### PR TITLE
Fix adding outline when `SceneSpawner` is not in the world

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -41,13 +41,13 @@ fn add_outline(
     mut commands: Commands,
     mut query: Query<(&mut AsyncSceneInheritOutline, Option<&SceneInstance>)>,
     systems: Res<AsyncSceneInheritOutlineSystems>,
-    scene_spawner: Res<SceneSpawner>,
+    scene_spawner: Option<Res<SceneSpawner>>, // Could be temporarily removed from the world when a scene is spawning
 ) {
     let Ok((mut scene_outline, scene_instance)) = query.get_mut(*entity_input) else {
         return;
     };
     let mut ready = false;
-    if let Some(scene_instance) = scene_instance {
+    if let (Some(scene_instance), Some(scene_spawner)) = (scene_instance, scene_spawner) {
         let iid = **scene_instance;
         if scene_spawner.instance_is_ready(iid) {
             for child in scene_spawner.iter_instance_entities(iid) {


### PR DESCRIPTION
Bevy removes it from the world when a scene is spawned via `SceneSpawner`:
https://github.com/bevyengine/bevy/blob/f667c282dad2c1419afb5836ded22a3ec263970e/crates/bevy_scene/src/scene_spawner.rs#L560

If `AsyncSceneInheritOutline` is inserted during the scene spawning (via a required component or via trigger), the system won't run since it requires `SceneSpawner`.

Tests use `DynamicSceneRoot` instead of using `SceneSpawner` directly and it works since it uses a bit different mechanism.

I noticed this in my game and tested the fix.

Looks like the crate still uses Rust 2021, so I can't use chained if let. I tried updating, but this requires a bunch of other changes in formatting and triggers a few clippy warnings, so I kept the version as is.