### PR TITLE
Support specifying a Core3dSystem set for outline shader to run in

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,6 +450,7 @@ fn add_dummy_phase_buffers(
 /// Adds support for rendering outlines.
 pub struct OutlinePlugin {
     mode: OutlineMode,
+    core3d_system_set: Core3dSystems,
 }
 
 impl OutlinePlugin {
@@ -457,6 +458,7 @@ impl OutlinePlugin {
     /// default. See [`OutlineMode::ExtrudeFlat`].
     pub const EXTRUDE_VERTEX: Self = Self {
         mode: OutlineMode::ExtrudeFlat,
+        core3d_system_set: Core3dSystems::PostProcess,
     };
 
     /// An [`OutlinePlugin`] configured to use jump-flood outlines by default.
@@ -464,6 +466,7 @@ impl OutlinePlugin {
     #[cfg(feature = "flood")]
     pub const JUMP_FLOOD: Self = Self {
         mode: OutlineMode::FloodFlat,
+        core3d_system_set: Core3dSystems::PostProcess,
     };
 }
 
@@ -583,7 +586,7 @@ impl Plugin for OutlinePlugin {
             Core3d,
             (msaa_extra_writeback_pass, outline_render_pass)
                 .chain()
-                .in_set(Core3dSystems::PostProcess)
+                .in_set(self.core3d_system_set)
                 .after(tonemapping)
                 .before(fxaa)
                 .before(smaa),


### PR DESCRIPTION
In its current state, this crate always runs the outline shader along with other PostProcessing nodes. If users want to run in EarlyPostProcess instead (to support other post-processing being able to modify the outline), this is not possible.
This change allows specifying a Core3dSystem set that the render pass should run in.