### PR TITLE
Fuse jump-flood outlines of grouped entities into one silhouette

### DIFF
--- a/src/computed.rs
+++ b/src/computed.rs
@@ -7,9 +7,9 @@ use bevy::{
 use crate::{
     pipeline_key::ComputedOutlineKey,
     uniforms::{DepthMode, DrawMode},
-    GlobalOutlineMode, InheritOutline, OutlineAlphaMask, OutlineFace, OutlineMode,
-    OutlinePlaneDepth, OutlineRenderLayers, OutlineStencil, OutlineStencilEnabled, OutlineVolume,
-    OutlineWarmUp, PropagateOutline,
+    GlobalOutlineMode, InheritOutline, OutlineAlphaMask, OutlineFace, OutlineMergeGroup,
+    OutlineMode, OutlinePlaneDepth, OutlineRenderLayers, OutlineStencil, OutlineStencilEnabled,
+    OutlineVolume, OutlineWarmUp, PropagateOutline,
 };
 
 #[derive(Clone)]
@@ -138,6 +138,7 @@ pub(crate) struct ComputedInternal {
     pub(crate) layers: Sourced<RenderLayers>,
     pub(crate) alpha_mask: Sourced<OutlineAlphaMask>,
     pub(crate) warm_up: Sourced<OutlineWarmUp>,
+    pub(crate) merge_group: Option<u32>,
 }
 
 /// A component for storing the computed depth at which the outline lies.
@@ -166,6 +167,7 @@ type OutlineComponents<'a> = (
     Option<Ref<'a, RenderLayers>>,
     Option<Ref<'a, OutlineAlphaMask>>,
     Option<Ref<'a, OutlineWarmUp>>,
+    Option<Ref<'a, OutlineMergeGroup>>,
 );
 
 #[allow(clippy::type_complexity)]
@@ -258,6 +260,7 @@ fn update_computed_outline(
         fallback_layers,
         alpha_mask,
         warm_up,
+        merge_group,
     ): QueryItem<'_, '_, OutlineComponents>,
     parent_computed: Option<&ComputedInternal>,
     parent_entity: Option<Entity>,
@@ -265,6 +268,7 @@ fn update_computed_outline(
     global_outline_mode: &GlobalOutlineMode,
 ) -> bool {
     let has_parent = parent_computed.is_some();
+    let new_merge_group = merge_group.as_ref().map(|mg| mg.0);
     let changed = force_update
         || if let ComputedOutline(Some(computed)) = computed.as_ref() {
             computed.inherited_from != parent_entity
@@ -279,6 +283,7 @@ fn update_computed_outline(
                     .layers
                     .is_changed_with_fallback(&layers, &fallback_layers, has_parent)
                 || computed.alpha_mask.is_changed(&alpha_mask, has_parent)
+                || computed.merge_group != new_merge_group
         } else {
             true
         };
@@ -367,6 +372,7 @@ fn update_computed_outline(
                 parent_computed.map(|p| p.warm_up.value.clone()),
                 |warm_up| warm_up.clone(),
             ),
+            merge_group: new_merge_group,
         });
     }
     changed

--- a/src/flood/flood_init.rs
+++ b/src/flood/flood_init.rs
@@ -112,6 +112,7 @@ pub(crate) fn queue_flood_meshes(
                 indexed: index_slab.is_some(),
                 volume_offset: outline.instance_data.volume_offset,
                 volume_colour: outline.instance_data.volume_colour,
+                merge_group: outline.merge_group,
             });
         }
 

--- a/src/flood/node.rs
+++ b/src/flood/node.rs
@@ -43,6 +43,7 @@ pub struct FloodOutline {
     pub indexed: bool,
     pub volume_offset: f32,
     pub volume_colour: Vec4,
+    pub merge_group: Option<u32>,
 }
 
 impl PhaseItem for FloodOutline {
@@ -89,10 +90,10 @@ impl CachedRenderPipelinePhaseItem for FloodOutline {
 }
 
 impl SortedPhaseItem for FloodOutline {
-    type SortKey = FloatOrd;
+    type SortKey = (Option<u32>, FloatOrd);
 
     fn sort_key(&self) -> Self::SortKey {
-        FloatOrd(self.distance)
+        (self.merge_group, FloatOrd(self.distance))
     }
 
     fn recalculate_sort_keys(
@@ -172,11 +173,24 @@ pub(crate) fn flood_render_pass(
         return;
     };
 
-    for ((_, volume_offset, _), group) in &flood_phase
-        .items
-        .values()
-        .enumerate()
-        .chunk_by(|(_, item)| (item.distance, item.volume_offset, item.volume_colour))
+    // When merge_group is Some, distance drops out of the key so members fuse.
+    for ((_, _, volume_offset, _), group) in
+        &flood_phase
+            .items
+            .values()
+            .enumerate()
+            .chunk_by(|(_, item)| {
+                let distance_key = match item.merge_group {
+                    Some(_) => FloatOrd(0.0),
+                    None => FloatOrd(item.distance),
+                };
+                (
+                    item.merge_group,
+                    distance_key,
+                    item.volume_offset,
+                    item.volume_colour,
+                )
+            })
     {
         let mut group_iter = group.into_iter();
         let Some((first_index, first_item)) = group_iter.next() else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,16 @@ pub struct PropagateOutline;
 #[cfg_attr(feature = "reflect", reflect(Component, Default))]
 pub struct StopPropagateOutline;
 
+/// A component for fusing jump-flood outlines into a single silhouette.
+///
+/// Entities with the same group id, [`OutlineVolume`] width, and colour share
+/// one flood mask, so interior edges between them vanish. Only affects
+/// [`OutlineMode::FloodFlat`]; not inherited from parent entities.
+#[derive(Clone, Copy, Component, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component, Default))]
+pub struct OutlineMergeGroup(pub u32);
+
 /// The channel of a texture.
 #[derive(Copy, Clone, Default)]
 #[cfg_attr(feature = "reflect", derive(Reflect))]
@@ -620,7 +630,8 @@ impl Plugin for OutlinePlugin {
             .register_type::<OutlineMsaa>()
             .register_type::<InheritOutline>()
             .register_type::<PropagateOutline>()
-            .register_type::<StopPropagateOutline>();
+            .register_type::<StopPropagateOutline>()
+            .register_type::<OutlineMergeGroup>();
 
         #[cfg(feature = "world_serialisation")]
         app.init_resource::<AsyncWorldInheritOutlineSystems>();

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -32,6 +32,7 @@ pub struct ExtractedOutline {
     pub(crate) automatic_batching: bool,
     pub(crate) instance_data: OutlineInstanceUniform,
     pub(crate) warm_up: OutlineWarmUp,
+    pub(crate) merge_group: Option<u32>,
 }
 
 #[derive(Resource, Default, Deref)]
@@ -145,6 +146,7 @@ pub(crate) fn extract_outlines(
                 current_morph_index: 0,
             },
             warm_up: computed.warm_up.value.clone(),
+            merge_group: computed.merge_group,
         };
         render_outlines
             .entity_map


### PR DESCRIPTION
### Motivation

Outlining several meshes at once (multi-select highlights, grouped props, etc) produces per-entity boundaries. Where the meshes overlap on screen the interior edges show through, and small parallax shifts as the camera moves make the boundaries fight against each other.

### Change

Adds an opt-in `OutlineMergeGroup(u32)` component. Entities that share a group id, an `OutlineVolume` width, and a color render into a shared mask during the flood pass, so interior edges disappear and only the outer silhouette of the union carries the outline.

Fully backwards compatible: entities without the component keep the existing per-entity behavior, driven by the same chunk key as before.

### Scope

- Affects `OutlineMode::FloodFlat` only. Extrude modes are untouched.
- Not inherited via `InheritOutline` / `PropagateOutline`: the group id is intrinsic to each rendered entity.
- Sort key becomes `(Option<u32>, FloatOrd)` so members of a group cluster contiguously, which is what lets `chunk_by` fuse them.